### PR TITLE
Remove 'meow' from 'possible' list

### DIFF
--- a/nekos/nekos.py
+++ b/nekos/nekos.py
@@ -17,7 +17,7 @@ def img(target: str):
     possible = [
         'feet', 'yuri', 'trap', 'futanari', 'hololewd', 'lewdkemo',
         'solog', 'feetg', 'cum', 'erokemo', 'les', 'wallpaper', 'lewdk',
-        'ngif', 'meow', 'tickle', 'lewd', 'feed', 'gecg', 'eroyuri', 'eron',
+        'ngif', 'tickle', 'lewd', 'feed', 'gecg', 'eroyuri', 'eron',
         'cum_jpg', 'bj', 'nsfw_neko_gif', 'solo', 'kemonomimi', 'nsfw_avatar',
         'gasm', 'poke', 'anal', 'slap', 'hentai', 'avatar', 'erofeet', 'holo',
         'keta', 'blowjob', 'pussy', 'tits', 'holoero', 'lizard', 'pussy_jpg',


### PR DESCRIPTION
Because the `img/meow/` endpoint is used in [here](https://github.com/Nekos-life/nekos.py/blob/master/nekos/nekos.py#L54-L58) 