### PR TITLE
Fix for random hentai gif

### DIFF
--- a/nekos/nekos.py
+++ b/nekos/nekos.py
@@ -22,7 +22,7 @@ def img(target: str):
         'gasm', 'poke', 'anal', 'slap', 'hentai', 'avatar', 'erofeet', 'holo',
         'keta', 'blowjob', 'pussy', 'tits', 'holoero', 'lizard', 'pussy_jpg',
         'pwankg', 'classic', 'kuni', 'waifu', 'pat', '8ball', 'kiss', 'femdom',
-        'neko', 'spank', 'cuddle', 'erok', 'fox_girl', 'boobs', 'Random_hentai_gif',
+        'neko', 'spank', 'cuddle', 'erok', 'fox_girl', 'boobs', 'random_hentai_gif',
         'smallboobs', 'hug', 'ero'
     ]
 


### PR DESCRIPTION
When trying to get a random hentai gif (Example: `print(nekos.img('Random_hentai_gif'))` or `print(nekos.img('random_hentai_gif')`) it throws an exception since the check at line 32 of nekos.py cannot find the search in the `possible` array as the search has been put to lower-case:
```py
# The search is set to 'random_hentai_gif' but the array value is 'Random_hentai_gif'
if target.lower() not in possible:
     raise errors.InvalidArgument("You haven't added any valid arguments\nArguments: {}".format(possible))
```

An alternative fix would be to use `possible.lower()`, but this is objectively cleaner